### PR TITLE
feat(debug): add optional label config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ We've all had occasions where we've felt the need to simply pipe a `tap(console.
 
 This operator aims to reduce the amount of typing you'll have to do!
 
-_P.S. This did originate as a meme idea :P_
-
 ## Usage
 
 ### Installation
@@ -42,6 +40,14 @@ Then pipe it to your Observables:
 const obs$ = source.pipe(debug());
 ```
 
+You can add a label to help identify the Observable:
+
+```ts
+const obs$ = source.pipe(debug('My Observable'));
+// OUTPUT
+// My Observable    {value}
+```
+
 It even allows you to turn it off if you are in a production environment, or for any other reason you wouldn't want to log to the console:
 
 ```ts
@@ -50,11 +56,43 @@ const obs$ = source.pipe(debug({ shouldIgnore: true }));
 
 ### Examples
 
-We can use it on it's own to simply log out values to the console
+We can use it on its own to simply log out values to the console
 
 ```ts
 const obs$ = of('my test value');
 obs$.pipe(debug()).subscribe();
+
+// OUTPUT:
+// my test value
+```
+
+We can add a label to the logs:
+
+```ts
+const obs$ = of('my test value');
+obs$.pipe(debug('Obserable A')).subscribe();
+
+// OUTPUT:
+// Obserable A    my test value
+
+// We can label it using the config object syntax:
+const obs$ = of('my test value');
+obs$.pipe(debug({ label: 'Obserable A' })).subscribe();
+
+// OUTPUT:
+// Obserable A    my test value
+
+// However, if we add a label and custom notification handlers,
+// we will not get the label in the logs by default:
+const obs$ = of('my test value');
+obs$
+  .pipe(
+    debug({
+      label: 'Obserable A',
+      next: (value) => console.log(value),
+    })
+  )
+  .subscribe();
 
 // OUTPUT:
 // my test value
@@ -98,9 +136,10 @@ obs$
 
 See the list of options available to configure the operator below
 
-| Option         |                            Description                             | Type                      | Default         |
-| -------------- | :----------------------------------------------------------------: | ------------------------- | --------------- |
-| `shouldIgnore` |                  Do not perform the Debug actions                  | `boolean`                 | `false`         |
-| `next`         |    Action to perform when Observer receives a Next notification    | `(value: T) => void`      | `console.log`   |
-| `error`        |   Action to perform when Observer receives an Error notification   | `(value: unkown) => void` | `console.error` |
-| `complete`     | Action to perform when Observer receives a Completion notification | `() => void`              | `() => null`    |
+| Option         |                            Description                             | Type                       | Default         |
+| -------------- | :----------------------------------------------------------------: | -------------------------- | --------------- |
+| `shouldIgnore` |                  Do not perform the Debug actions                  | `boolean`                  | `false`         |
+| `label`        |      Add a label to the logs to help identify the Observable       | `string`                   | `null`          |
+| `next`         |    Action to perform when Observer receives a Next notification    | `(value: T) => void`       | `console.log`   |
+| `error`        |   Action to perform when Observer receives an Error notification   | `(value: unknown) => void` | `console.error` |
+| `complete`     | Action to perform when Observer receives a Completion notification | `() => void`               | `() => null`    |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxjs-debug-operator",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "scripts": {
     "nx": "nx",

--- a/packages/operators/debug/README.md
+++ b/packages/operators/debug/README.md
@@ -15,8 +15,6 @@ We've all had occasions where we've felt the need to simply pipe a `tap(console.
 
 This operator aims to reduce the amount of typing you'll have to do!
 
-_P.S. This did originate as a meme idea :P_
-
 ## Usage
 
 ### Installation
@@ -42,6 +40,14 @@ Then pipe it to your Observables:
 const obs$ = source.pipe(debug());
 ```
 
+You can add a label to help identify the Observable:
+
+```ts
+const obs$ = source.pipe(debug('My Observable'));
+// OUTPUT
+// My Observable    {value}
+```
+
 It even allows you to turn it off if you are in a production environment, or for any other reason you wouldn't want to log to the console:
 
 ```ts
@@ -50,11 +56,43 @@ const obs$ = source.pipe(debug({ shouldIgnore: true }));
 
 ### Examples
 
-We can use it on it's own to simply log out values to the console
+We can use it on its own to simply log out values to the console
 
 ```ts
 const obs$ = of('my test value');
 obs$.pipe(debug()).subscribe();
+
+// OUTPUT:
+// my test value
+```
+
+We can add a label to the logs:
+
+```ts
+const obs$ = of('my test value');
+obs$.pipe(debug('Obserable A')).subscribe();
+
+// OUTPUT:
+// Obserable A    my test value
+
+// We can label it using the config object syntax:
+const obs$ = of('my test value');
+obs$.pipe(debug({ label: 'Obserable A' })).subscribe();
+
+// OUTPUT:
+// Obserable A    my test value
+
+// However, if we add a label and custom notification handlers,
+// we will not get the label in the logs by default:
+const obs$ = of('my test value');
+obs$
+  .pipe(
+    debug({
+      label: 'Obserable A',
+      next: (value) => console.log(value),
+    })
+  )
+  .subscribe();
 
 // OUTPUT:
 // my test value
@@ -98,9 +136,10 @@ obs$
 
 See the list of options available to configure the operator below
 
-| Option         |                            Description                             | Type                      | Default         |
-| -------------- | :----------------------------------------------------------------: | ------------------------- | --------------- |
-| `shouldIgnore` |                  Do not perform the Debug actions                  | `boolean`                 | `false`         |
-| `next`         |    Action to perform when Observer receives a Next notification    | `(value: T) => void`      | `console.log`   |
-| `error`        |   Action to perform when Observer receives an Error notification   | `(value: unkown) => void` | `console.error` |
-| `complete`     | Action to perform when Observer receives a Completion notification | `() => void`              | `() => null`    |
+| Option         |                            Description                             | Type                       | Default         |
+| -------------- | :----------------------------------------------------------------: | -------------------------- | --------------- |
+| `shouldIgnore` |                  Do not perform the Debug actions                  | `boolean`                  | `false`         |
+| `label`        |      Add a label to the logs to help identify the Observable       | `string`                   | `null`          |
+| `next`         |    Action to perform when Observer receives a Next notification    | `(value: T) => void`       | `console.log`   |
+| `error`        |   Action to perform when Observer receives an Error notification   | `(value: unknown) => void` | `console.error` |
+| `complete`     | Action to perform when Observer receives a Completion notification | `() => void`               | `() => null`    |

--- a/packages/operators/debug/package.json
+++ b/packages/operators/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxjs-debug-operator",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/Coly010/rxjs-debug-operator"

--- a/packages/operators/debug/src/lib/operators-debug.spec.ts
+++ b/packages/operators/debug/src/lib/operators-debug.spec.ts
@@ -57,7 +57,7 @@ describe('operators - debug', () => {
   });
 
   describe('when custom handlers are used', () => {
-    let config: DebugOperatorConfig<string>;
+    let config: Partial<DebugOperatorConfig<string>>;
 
     beforeEach(
       () =>
@@ -223,7 +223,7 @@ describe('operators - debug', () => {
     describe('and when shouldIgnore is true', () => {
       beforeEach(() => (config.shouldIgnore = true));
 
-      it('should log value to the console when next notification receieved', () => {
+      it('should not log value to the console when next notification receieved', () => {
         // ARRANGE
         const obs$ = of('my test value');
 
@@ -237,7 +237,7 @@ describe('operators - debug', () => {
         );
       });
 
-      it('should error value to the console when error notification receieved', () => {
+      it('should not error value to the console when error notification receieved', () => {
         // ARRANGE
         const obs$ = throwError('my error value');
 
@@ -248,7 +248,7 @@ describe('operators - debug', () => {
         expect(console.error).not.toHaveBeenCalledWith('my error value');
       });
 
-      it('should log value to the console when complete notification receieved', () => {
+      it('should not log value to the console when complete notification receieved', () => {
         // ARRANGE
         const obs$ = of('my test value');
 
@@ -261,6 +261,141 @@ describe('operators - debug', () => {
           2,
           'I received a completion'
         );
+      });
+    });
+  });
+
+  describe('when a label is used', () => {
+    describe('using a string param', () => {
+      it('should log value to the console when next notification receieved with the label', () => {
+        // ARRANGE
+        const obs$ = of('my test value');
+
+        // ACT
+        obs$.pipe(debug('Test Label')).subscribe();
+
+        // ASSERT
+        expect(console.log).toHaveBeenCalledWith('Test Label', 'my test value');
+      });
+
+      it('should error value to the console when error notification receieved with the label', () => {
+        // ARRANGE
+        const obs$ = throwError('my error value');
+
+        // ACT
+        obs$.pipe(debug('Test Label')).subscribe();
+
+        // ASSERT
+        expect(console.error).toHaveBeenCalledWith(
+          'Test Label',
+          'my error value'
+        );
+      });
+    });
+
+    describe('using the config object', () => {
+      let config: Partial<DebugOperatorConfig<string>>;
+
+      beforeEach(
+        () =>
+          (config = {
+            shouldIgnore: false,
+            label: 'Test Label',
+          })
+      );
+
+      describe('and when shouldIgnore is false', () => {
+        beforeEach(() => (config.shouldIgnore = false));
+
+        it('should log value to the console when next notification receieved', () => {
+          // ARRANGE
+          const obs$ = of('my test value');
+
+          // ACT
+          obs$.pipe(debug(config)).subscribe();
+
+          // ASSERT
+          expect(console.log).toHaveBeenCalledWith(
+            'Test Label',
+            'my test value'
+          );
+        });
+
+        it('should error value to the console when error notification receieved', () => {
+          // ARRANGE
+          const obs$ = throwError('my error value');
+
+          // ACT
+          obs$.pipe(debug(config)).subscribe();
+
+          // ASSERT
+          expect(console.error).toHaveBeenCalledWith(
+            'Test Label',
+            'my error value'
+          );
+        });
+
+        it('should log value to the console when complete notification receieved', () => {
+          // ARRANGE
+          const obs$ = of('my test value');
+
+          // ACT
+          obs$.pipe(debug(config)).subscribe();
+
+          // ASSERT
+          expect(console.log).toHaveBeenCalledTimes(2);
+          expect(console.log).toHaveBeenNthCalledWith(
+            2,
+            'Test Label completed'
+          );
+        });
+      });
+
+      describe('and when shouldIgnore is true', () => {
+        beforeEach(() => (config.shouldIgnore = true));
+
+        it('should not log value to the console when next notification receieved', () => {
+          // ARRANGE
+          const obs$ = of('my test value');
+
+          // ACT
+          obs$.pipe(debug(config)).subscribe();
+
+          // ASSERT
+          expect(console.log).not.toHaveBeenCalledWith(
+            'Test Label',
+            'my test value'
+          );
+        });
+
+        it('should not error value to the console when error notification receieved', () => {
+          // ARRANGE
+          const obs$ = throwError('my error value');
+
+          // ACT
+          obs$.pipe(debug(config)).subscribe();
+
+          // ASSERT
+          expect(console.error).not.toHaveBeenCalledWith(
+            'Test Label',
+            'my error value'
+          );
+        });
+
+        it('should not log value to the console when complete notification receieved', () => {
+          // ARRANGE
+          const obs$ = of('my test value');
+
+          // ACT
+          obs$.pipe(debug(config)).subscribe();
+
+          // ASSERT
+          expect(console.log).not.toHaveBeenCalledTimes(2);
+          expect(console.log).not.toHaveBeenNthCalledWith(
+            2,
+            'Test Label completed'
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
## Description
This adds an option to allow the developer to add labels to the logs, to help identify which Observable is being logged.

## Example
```ts
const obs$ = of('my test value');
obs$.pipe(debug('Obserable A')).subscribe();

// OUTPUT:
// Obserable A    my test value

// We can label it using the config object syntax:
const obs$ = of('my test value');
obs$.pipe(debug({ label: 'Obserable A' })).subscribe();

// OUTPUT:
// Obserable A    my test value

// However, if we add a label and custom notification handlers,
// we will not get the label in the logs by default:
const obs$ = of('my test value');
obs$
  .pipe(
    debug({
      label: 'Obserable A',
      next: (value) => console.log(value),
    })
  )
  .subscribe();

// OUTPUT:
// my test value
```