### PR TITLE
feat(debug): add global config options

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: npm install
-      - run: npm run affected:test
+      - run: npm run test -- --project=operators-debug

--- a/README.md
+++ b/README.md
@@ -126,9 +126,82 @@ obs$
 // I completed
 ```
 
+We can access the default logger for more flexibility:
+
+```js
+const obs$ = of('my test value');
+
+obs$
+  .pipe(
+    debug((logger) => ({
+      next: (v) => logger.warn('Warning!', v),
+    }))
+  )
+  .subscribe();
+
+// OUTPUT
+// WARN: Warning!   my test value
+```
+
+## Setting Global Config
+
+You can set some globals that make it more convenient to change:
+
+- the default logger
+- a global prefix to be appended to all logs
+- a global-level ignore flag
+
+### Change the Default Logger
+
+You can change the default logger by creating an object that matches the `DebugLogger` interface, which can be seen below:
+
+```ts
+export interface DebugLogger {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+  debug?: (...args: unknown[]) => void;
+  info?: (...args: unknown[]) => void;
+}
+```
+
+Once you have created your new logger, you can set it to be used as the default logger using `setGlobalDebugConfig()`
+
+```js
+setGlobalDebugConfig({
+  logger: myNewLogger,
+});
+```
+
+Now all your `debug()` operators will use your new logger to log the values it receives.
+
+### Adding a Global Prefix
+
+You can also add a string prefix to all your logs at a global level, which can be useful to help identify logs.
+
+```js
+setGlobalDebugConfig({
+  prefix: myNewLogger,
+});
+```
+
+### Setting whether to ignore logging
+
+You can also set whether all `debug()` should not log at the global level. This can be useful for turning it off in production environments.
+
+```js
+setGlobalDebugConfig({
+  shouldIgnore: isProduction,
+});
+```
+
+### **NOTES**
+
+**It should be noted that local config options passed to the `debug()` operator will take precedence over any global values**
+
 ## API
 
-### Signature
+### Debug
 
 `debug(config?: Partial<DebugOperatorConfig>)`
 
@@ -143,3 +216,25 @@ See the list of options available to configure the operator below
 | `next`         |    Action to perform when Observer receives a Next notification    | `(value: T) => void`       | `console.log`   |
 | `error`        |   Action to perform when Observer receives an Error notification   | `(value: unknown) => void` | `console.error` |
 | `complete`     | Action to perform when Observer receives a Completion notification | `() => void`               | `() => null`    |
+
+### Global Debug Config
+
+`setGlobalDebugConfig(config: Partial<GlobalDebugConfig>)`
+
+### GlobalDebugConfig
+
+| Option         |                       Description                       | Type          | Default   |
+| -------------- | :-----------------------------------------------------: | ------------- | --------- |
+| `shouldIgnore` |            Do not perform the Debug actions             | `boolean`     | `false`   |
+| `prefix`       | Add a label to the logs to help identify the Observable | `string`      | `null`    |
+| `logger`       |    Logger to use to log values recieved by `debug()`    | `DebugLogger` | `console` |
+
+### DebugLogger
+
+| Option   | Description | Type                           | Default         |
+| -------- | :---------: | ------------------------------ | --------------- |
+| `log`    |  Basic log  | `(...args: unknown[]) => void` | `console.log`   |
+| `error`  |  Error log  | `(...args: unknown[]) => void` | `console.error` |
+| `info?`  |  Info log   | `(...args: unknown[]) => void` | `console.info`  |
+| `warn?`  |  Warn log   | `(...args: unknown[]) => void` | `console.warn`  |
+| `debug?` |  Debug log  | `(...args: unknown[]) => void` | `console.debug` |

--- a/packages/operators/debug/README.md
+++ b/packages/operators/debug/README.md
@@ -126,9 +126,82 @@ obs$
 // I completed
 ```
 
+We can access the default logger for more flexibility:
+
+```js
+const obs$ = of('my test value');
+
+obs$
+  .pipe(
+    debug((logger) => ({
+      next: (v) => logger.warn('Warning!', v),
+    }))
+  )
+  .subscribe();
+
+// OUTPUT
+// WARN: Warning!   my test value
+```
+
+## Setting Global Config
+
+You can set some globals that make it more convenient to change:
+
+- the default logger
+- a global prefix to be appended to all logs
+- a global-level ignore flag
+
+### Change the Default Logger
+
+You can change the default logger by creating an object that matches the `DebugLogger` interface, which can be seen below:
+
+```ts
+export interface DebugLogger {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+  debug?: (...args: unknown[]) => void;
+  info?: (...args: unknown[]) => void;
+}
+```
+
+Once you have created your new logger, you can set it to be used as the default logger using `setGlobalDebugConfig()`
+
+```js
+setGlobalDebugConfig({
+  logger: myNewLogger,
+});
+```
+
+Now all your `debug()` operators will use your new logger to log the values it receives.
+
+### Adding a Global Prefix
+
+You can also add a string prefix to all your logs at a global level, which can be useful to help identify logs.
+
+```js
+setGlobalDebugConfig({
+  prefix: myNewLogger,
+});
+```
+
+### Setting whether to ignore logging
+
+You can also set whether all `debug()` should not log at the global level. This can be useful for turning it off in production environments.
+
+```js
+setGlobalDebugConfig({
+  shouldIgnore: isProduction,
+});
+```
+
+### **NOTES**
+
+**It should be noted that local config options passed to the `debug()` operator will take precedence over any global values**
+
 ## API
 
-### Signature
+### Debug
 
 `debug(config?: Partial<DebugOperatorConfig>)`
 
@@ -143,3 +216,25 @@ See the list of options available to configure the operator below
 | `next`         |    Action to perform when Observer receives a Next notification    | `(value: T) => void`       | `console.log`   |
 | `error`        |   Action to perform when Observer receives an Error notification   | `(value: unknown) => void` | `console.error` |
 | `complete`     | Action to perform when Observer receives a Completion notification | `() => void`               | `() => null`    |
+
+### Global Debug Config
+
+`setGlobalDebugConfig(config: Partial<GlobalDebugConfig>)`
+
+### GlobalDebugConfig
+
+| Option         |                       Description                       | Type          | Default   |
+| -------------- | :-----------------------------------------------------: | ------------- | --------- |
+| `shouldIgnore` |            Do not perform the Debug actions             | `boolean`     | `false`   |
+| `prefix`       | Add a label to the logs to help identify the Observable | `string`      | `null`    |
+| `logger`       |    Logger to use to log values recieved by `debug()`    | `DebugLogger` | `console` |
+
+### DebugLogger
+
+| Option   | Description | Type                           | Default         |
+| -------- | :---------: | ------------------------------ | --------------- |
+| `log`    |  Basic log  | `(...args: unknown[]) => void` | `console.log`   |
+| `error`  |  Error log  | `(...args: unknown[]) => void` | `console.error` |
+| `info?`  |  Info log   | `(...args: unknown[]) => void` | `console.info`  |
+| `warn?`  |  Warn log   | `(...args: unknown[]) => void` | `console.warn`  |
+| `debug?` |  Debug log  | `(...args: unknown[]) => void` | `console.debug` |

--- a/packages/operators/debug/src/lib/debug-config.ts
+++ b/packages/operators/debug/src/lib/debug-config.ts
@@ -1,0 +1,53 @@
+import { Observer } from 'rxjs/internal/types';
+import { DebugLogger, defaultLogger } from './debug-logger';
+
+export interface GlobalDebugConfig {
+  logger: DebugLogger;
+  prefix: string;
+  shouldIgnore: boolean;
+}
+
+export function createDefaultGlobalDebugConfig() {
+  return {
+    logger: defaultLogger,
+    prefix: null,
+    shouldIgnore: false,
+  };
+}
+
+/**
+ * @private DO NOT USE DIRECTLY
+ */
+export let GLOBAL_CONFIG: GlobalDebugConfig = createDefaultGlobalDebugConfig();
+
+export function setGlobalDebugConfig(config: Partial<GlobalDebugConfig>) {
+  GLOBAL_CONFIG = { ...GLOBAL_CONFIG, ...config };
+}
+
+export interface DebugOperatorConfig<T> extends Omit<Observer<T>, 'closed'> {
+  shouldIgnore: boolean;
+  label: string;
+  next: (value: T) => void;
+  error: (value: unknown) => void;
+  complete: () => void;
+}
+
+export function createDefaultConfig<T>(
+  label: string = null
+): DebugOperatorConfig<T> {
+  const { logger, prefix, shouldIgnore } = GLOBAL_CONFIG;
+
+  if (!label && prefix) {
+    label = prefix;
+  } else if (label && prefix) {
+    label = `${prefix} ${label}`;
+  }
+
+  return {
+    shouldIgnore,
+    label,
+    next: label ? (v) => logger.log(label, v) : logger.log,
+    error: label ? (e) => logger.error(label, e) : logger.error,
+    complete: label ? () => logger.log(`${label} completed`) : () => null,
+  };
+}

--- a/packages/operators/debug/src/lib/debug-config.ts
+++ b/packages/operators/debug/src/lib/debug-config.ts
@@ -1,28 +1,5 @@
 import { Observer } from 'rxjs/internal/types';
-import { DebugLogger, defaultLogger } from './debug-logger';
-
-export interface GlobalDebugConfig {
-  logger: DebugLogger;
-  prefix: string;
-  shouldIgnore: boolean;
-}
-
-export function createDefaultGlobalDebugConfig() {
-  return {
-    logger: defaultLogger,
-    prefix: null,
-    shouldIgnore: false,
-  };
-}
-
-/**
- * @private DO NOT USE DIRECTLY
- */
-export let GLOBAL_CONFIG: GlobalDebugConfig = createDefaultGlobalDebugConfig();
-
-export function setGlobalDebugConfig(config: Partial<GlobalDebugConfig>) {
-  GLOBAL_CONFIG = { ...GLOBAL_CONFIG, ...config };
-}
+import { GLOBAL_CONFIG } from './global-debug-config';
 
 export interface DebugOperatorConfig<T> extends Omit<Observer<T>, 'closed'> {
   shouldIgnore: boolean;

--- a/packages/operators/debug/src/lib/debug-logger.ts
+++ b/packages/operators/debug/src/lib/debug-logger.ts
@@ -1,0 +1,15 @@
+export interface DebugLogger {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+  debug?: (...args: unknown[]) => void;
+  info?: (...args: unknown[]) => void;
+}
+
+export const defaultLogger: DebugLogger = {
+  log: console.log,
+  error: console.error,
+  warn: console.warn,
+  debug: console.debug,
+  info: console.info,
+};

--- a/packages/operators/debug/src/lib/global-debug-config.ts
+++ b/packages/operators/debug/src/lib/global-debug-config.ts
@@ -1,0 +1,24 @@
+import { DebugLogger, defaultLogger } from './debug-logger';
+
+export interface GlobalDebugConfig {
+  logger: DebugLogger;
+  prefix: string;
+  shouldIgnore: boolean;
+}
+
+export function createDefaultGlobalDebugConfig() {
+  return {
+    logger: defaultLogger,
+    prefix: null,
+    shouldIgnore: false,
+  };
+}
+
+export function setGlobalDebugConfig(config: Partial<GlobalDebugConfig>) {
+  GLOBAL_CONFIG = { ...GLOBAL_CONFIG, ...config };
+}
+
+/**
+ * @private DO NOT USE DIRECTLY
+ */
+export let GLOBAL_CONFIG: GlobalDebugConfig = createDefaultGlobalDebugConfig();

--- a/packages/operators/debug/src/lib/operators-debug.spec.ts
+++ b/packages/operators/debug/src/lib/operators-debug.spec.ts
@@ -1,10 +1,10 @@
 import { of, throwError } from 'rxjs';
+import { DebugOperatorConfig } from './debug-config';
+import { DebugLogger } from './debug-logger';
 import {
   createDefaultGlobalDebugConfig,
-  DebugOperatorConfig,
   setGlobalDebugConfig,
-} from './debug-config';
-import { DebugLogger } from './debug-logger';
+} from './global-debug-config';
 import { debug } from './operators-debug';
 
 describe('operators - debug', () => {

--- a/packages/operators/debug/src/lib/operators-debug.spec.ts
+++ b/packages/operators/debug/src/lib/operators-debug.spec.ts
@@ -1,11 +1,25 @@
 import { of, throwError } from 'rxjs';
-import { take } from 'rxjs/operators';
-import { debug, DebugOperatorConfig } from './operators-debug';
+import {
+  createDefaultGlobalDebugConfig,
+  DebugOperatorConfig,
+  setGlobalDebugConfig,
+} from './debug-config';
+import { DebugLogger } from './debug-logger';
+import { debug } from './operators-debug';
 
 describe('operators - debug', () => {
+  let testLogger: DebugLogger;
+
   beforeEach(() => {
     console.log = jest.fn();
     console.error = jest.fn();
+
+    testLogger = {
+      log: console.log,
+      error: console.error,
+    };
+
+    setGlobalDebugConfig({ logger: testLogger });
   });
 
   describe('when shouldIgnore is false', () => {
@@ -17,7 +31,7 @@ describe('operators - debug', () => {
       obs$.pipe(debug()).subscribe();
 
       // ASSERT
-      expect(console.log).toHaveBeenCalledWith('my test value');
+      expect(testLogger.log).toHaveBeenCalledWith('my test value');
     });
 
     it('should error value to the console when error notification receieved', () => {
@@ -28,7 +42,7 @@ describe('operators - debug', () => {
       obs$.pipe(debug()).subscribe();
 
       // ASSERT
-      expect(console.error).toHaveBeenCalledWith('my error value');
+      expect(testLogger.error).toHaveBeenCalledWith('my error value');
     });
   });
 
@@ -396,6 +410,148 @@ describe('operators - debug', () => {
             'Test Label completed'
           );
         });
+      });
+    });
+  });
+
+  describe('when we change the global config', () => {
+    describe('by setting a new logger', () => {
+      beforeEach(() => {
+        console.warn = jest.fn();
+        console.debug = jest.fn();
+
+        setGlobalDebugConfig({
+          logger: {
+            log: console.warn,
+            error: console.debug,
+          },
+        });
+      });
+
+      it('should use the new logger to log the next notification', () => {
+        // ARRANGE
+        const obs$ = of('my test value');
+
+        // ACT
+        obs$.pipe(debug()).subscribe();
+
+        // ASSERT
+        expect(console.warn).toHaveBeenCalled();
+        expect(console.warn).toHaveBeenCalledWith('my test value');
+      });
+
+      it('should use the new logger to log the error notification', () => {
+        // ARRANGE
+        const obs$ = throwError('my error value');
+
+        // ACT
+        obs$.pipe(debug()).subscribe();
+
+        // ASSERT
+        expect(console.debug).toHaveBeenCalled();
+        expect(console.debug).toHaveBeenCalledWith('my error value');
+      });
+
+      it('should allow for local overwrites of global config', () => {
+        // ARRANGE
+        const obs$ = of('my test value');
+
+        // ACT
+        obs$.pipe(debug({ next: console.log })).subscribe();
+
+        // ASSERT
+        expect(console.log).toHaveBeenCalled();
+        expect(console.log).toHaveBeenCalledWith('my test value');
+      });
+
+      it('should allow usage of the global logger for local overwrites', () => {
+        // ARRANGE
+        const obs$ = of('my test value');
+
+        // ACT
+        obs$
+          .pipe(
+            debug((logger) => ({
+              next: () => logger.log('I changed this completely'),
+            }))
+          )
+          .subscribe();
+
+        // ASSERT
+        expect(console.warn).toHaveBeenCalled();
+        expect(console.warn).toHaveBeenCalledWith('I changed this completely');
+      });
+    });
+
+    describe('by setting a prefix', () => {
+      beforeEach(() => {
+        setGlobalDebugConfig({
+          prefix: 'Test Prefix',
+        });
+      });
+
+      it('should use the new prefix when logging the next notification', () => {
+        // ARRANGE
+        const obs$ = of('my test value');
+
+        // ACT
+        obs$.pipe(debug()).subscribe();
+
+        // ASSERT
+        expect(console.log).toHaveBeenCalled();
+        expect(console.log).toHaveBeenCalledWith(
+          'Test Prefix',
+          'my test value'
+        );
+      });
+
+      it('should prepend the new prefix to a label when logging the next notification', () => {
+        // ARRANGE
+        const obs$ = of('my test value');
+
+        // ACT
+        obs$.pipe(debug('my label')).subscribe();
+
+        // ASSERT
+        expect(console.log).toHaveBeenCalled();
+        expect(console.log).toHaveBeenCalledWith(
+          'Test Prefix my label',
+          'my test value'
+        );
+      });
+    });
+
+    describe('by setting a global shouldIgnore value', () => {
+      beforeEach(() => {
+        setGlobalDebugConfig({
+          ...createDefaultGlobalDebugConfig(),
+          logger: testLogger, // Have to reset to get the Jest Mock
+          shouldIgnore: true,
+        });
+      });
+
+      it('should not log the next notification', () => {
+        // ARRANGE
+        const obs$ = of('my test value');
+
+        // ACT
+        obs$.pipe(debug()).subscribe();
+
+        // ASSERT
+        expect(console.log).not.toHaveBeenCalled();
+        expect(console.log).not.toHaveBeenCalledWith('my test value');
+      });
+
+      it('should allow local overwrite of global shouldIgnore', () => {
+        // ARRANGE
+        const obs$ = of('my test value');
+
+        // ACT
+        obs$.pipe(debug({ shouldIgnore: false })).subscribe();
+
+        // ASSERT
+        expect(console.log).toHaveBeenCalled();
+        expect(console.log).toHaveBeenCalledWith('my test value');
       });
     });
   });

--- a/packages/operators/debug/src/lib/operators-debug.ts
+++ b/packages/operators/debug/src/lib/operators-debug.ts
@@ -1,12 +1,9 @@
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { MonoTypeOperatorFunction } from 'rxjs/internal/types';
-import {
-  createDefaultConfig,
-  DebugOperatorConfig,
-  GLOBAL_CONFIG,
-} from './debug-config';
+import { createDefaultConfig, DebugOperatorConfig } from './debug-config';
 import { DebugLogger } from './debug-logger';
+import { GLOBAL_CONFIG } from './global-debug-config';
 
 /**
  * Used to help debug the observable as it receives notifications


### PR DESCRIPTION
## Description

This PR introduces a new global config option.

This will allow the following:

You can set some globals that make it more convenient to change:

- the default logger
- a global prefix to be appended to all logs
- a global-level ignore flag

### Change the Default Logger

You can change the default logger by creating an object that matches the `DebugLogger` interface, which can be seen below:

```ts
export interface DebugLogger {
  log: (...args: unknown[]) => void;
  error: (...args: unknown[]) => void;
  warn?: (...args: unknown[]) => void;
  debug?: (...args: unknown[]) => void;
  info?: (...args: unknown[]) => void;
}
```

Once you have created your new logger, you can set it to be used as the default logger using `setGlobalDebugConfig()`

```js
setGlobalDebugConfig({
  logger: myNewLogger,
});
```

Now all your `debug()` operators will use your new logger to log the values it receives.

### Adding a Global Prefix

You can also add a string prefix to all your logs at a global level, which can be useful to help identify logs.

```js
setGlobalDebugConfig({
  prefix: 'My Prefix',
});
```

### Setting whether to ignore logging

You can also set whether all `debug()` should not log at the global level. This can be useful for turning it off in production environments.

```js
setGlobalDebugConfig({
  shouldIgnore: isProduction,
});
```

### **NOTES**

**It should be noted that local config options passed to the `debug()` operator will take precedence over any global values**
